### PR TITLE
Dropping all the unused parts of lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "any-shell-escape": "^0.1.1",
     "babel-runtime": "^5.8.3",
-    "lodash": "^3.7.0",
+    "lodash.zip": "^4.0.0",
     "source-map-support": "^0.3.2"
   },
   "devDependencies": {

--- a/src/shell-escape-tag.js
+++ b/src/shell-escape-tag.js
@@ -1,4 +1,4 @@
-import _           from 'lodash';
+import zip         from 'lodash.zip'
 import shellEscape from 'any-shell-escape';
 
 import 'source-map-support/register';
@@ -34,7 +34,7 @@ class Escaped {
 function _shellEscape (params, options = {}) {
     if (params instanceof Escaped) {
         return params.value;
-    } else if (_.isArray(params)) {
+    } else if (Array.isArray(params)) {
         let escaped = [];
 
         for (let value of params) {
@@ -58,7 +58,7 @@ function _shellEscape (params, options = {}) {
 export default function shell (strings, ...params) {
     let result = '';
 
-    for (let [ string, param ] of _.zip(strings, params)) {
+    for (let [ string, param ] of zip(strings, params)) {
         result += string + _shellEscape(param);
     }
 


### PR DESCRIPTION
Just for the benefit of faster installs.

- Switching to a more narrowly-scoped import of _.zip.
- Also switched to using native Array.isArray.

Switching to the native Array.isArray theoretically drops ES3 support, but I took the liberty of assuming that it wasn't a high priority for this module.  (lodash 4.0 `isArray` just exports `Array.isArray`).